### PR TITLE
Disabled unnecessary assertions

### DIFF
--- a/src/indexgenerator.cpp
+++ b/src/indexgenerator.cpp
@@ -187,7 +187,6 @@ size_t meshopt_generateVertexRemap(unsigned int* destination, const unsigned int
 	using namespace meshopt;
 
 	assert(indices || index_count == vertex_count);
-	assert(!indices || index_count % 3 == 0);
 	assert(vertex_size > 0 && vertex_size <= 256);
 
 	meshopt_Allocator allocator;
@@ -236,7 +235,6 @@ size_t meshopt_generateVertexRemapMulti(unsigned int* destination, const unsigne
 	using namespace meshopt;
 
 	assert(indices || index_count == vertex_count);
-	assert(index_count % 3 == 0);
 	assert(stream_count > 0 && stream_count <= 16);
 
 	for (size_t i = 0; i < stream_count; ++i)
@@ -313,8 +311,6 @@ void meshopt_remapVertexBuffer(void* destination, const void* vertices, size_t v
 
 void meshopt_remapIndexBuffer(unsigned int* destination, const unsigned int* indices, size_t index_count, const unsigned int* remap)
 {
-	assert(index_count % 3 == 0);
-
 	for (size_t i = 0; i < index_count; ++i)
 	{
 		unsigned int index = indices ? indices[i] : unsigned(i);
@@ -329,7 +325,6 @@ void meshopt_generateShadowIndexBuffer(unsigned int* destination, const unsigned
 	using namespace meshopt;
 
 	assert(indices);
-	assert(index_count % 3 == 0);
 	assert(vertex_size > 0 && vertex_size <= 256);
 	assert(vertex_size <= vertex_stride);
 
@@ -368,7 +363,6 @@ void meshopt_generateShadowIndexBufferMulti(unsigned int* destination, const uns
 	using namespace meshopt;
 
 	assert(indices);
-	assert(index_count % 3 == 0);
 	assert(stream_count > 0 && stream_count <= 16);
 
 	for (size_t i = 0; i < stream_count; ++i)


### PR DESCRIPTION
Most index remapping functions from indexgenerator.cpp operate on bitwise equality of vertices and perform remap index-by-index without assumptions about mesh primitives. Since we were using these functions for optimizing line-primitive meshes for the STEP file importer I have removed `index_count % 3 ==0` assertions for relevant remapping functions (ones without assumption about buffer topology, so functions like `meshopt_generateAdjacencyIndexBuffer` still have that assertion) which makes them automatically work for removing duplicate geometry for other mesh topologies.